### PR TITLE
Rear/back camera by default, improved spacing for Interpretation display

### DIFF
--- a/camera.html
+++ b/camera.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
+<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="author" content="ZXing for JS">
 
@@ -101,20 +101,21 @@
           const sourceSelect = document.getElementById('sourceSelect')
           selectedDeviceId = videoInputDevices[0].deviceId
           if (videoInputDevices.length >= 1) {
-          	let i=0;
-          	let s=null;
+            let i=0;
+            let s=null;
             videoInputDevices.forEach((element) => {
               const sourceOption = document.createElement('option')
               sourceOption.text = element.label
-              if ((element.label.indexOf('rear') > -1) || (element.label.indexOf('back') > -1)) {
-              	s=i;
+              if ((element.label.indexOf("rear") > -1) || (element.label.indexOf("back") > -1)) {
+                  s=i;
               }
               sourceOption.value = element.deviceId
               sourceSelect.appendChild(sourceOption)
-              i++
+              i++;
             })
             if (s !== null) {
-            	sourceSelect.selectedIndex=s;
+                sourceSelect.selectedIndex  = s;
+                selectedDeviceId = sourceSelect.value;
             }
 
             sourceSelect.onchange = () => {

--- a/camera.html
+++ b/camera.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -101,12 +101,21 @@
           const sourceSelect = document.getElementById('sourceSelect')
           selectedDeviceId = videoInputDevices[0].deviceId
           if (videoInputDevices.length >= 1) {
+          	let i=0;
+          	let s=null;
             videoInputDevices.forEach((element) => {
               const sourceOption = document.createElement('option')
               sourceOption.text = element.label
+              if ((element.label.indexOf('rear') > -1) || (element.label.indexOf('back') > -1)) {
+              	s=i;
+              }
               sourceOption.value = element.deviceId
               sourceSelect.appendChild(sourceOption)
+              i++
             })
+            if (s !== null) {
+            	sourceSelect.selectedIndex=s;
+            }
 
             sourceSelect.onchange = () => {
               selectedDeviceId = sourceSelect.value;

--- a/camera.html
+++ b/camera.html
@@ -14,12 +14,12 @@
 
   <style>
     p.aiDisplay span.ai {
-      width: 2em;
+      width: 3em;
       padding-right: 1em;
     }
 
     p.aiDisplay span.aiLabel {
-      width: 12em;
+      width: 13em;
       padding-right: 1em;
     }
 

--- a/camera.html
+++ b/camera.html
@@ -15,10 +15,12 @@
   <style>
     p.aiDisplay span.ai {
       width: 2em;
+      padding-right: 1em;
     }
 
     p.aiDisplay span.aiLabel {
       width: 12em;
+      padding-right: 1em;
     }
 
     div#syntaxes p label {


### PR DESCRIPTION
Hi Phil,

I've modified a fork of your repository to add a bit of extra JavaScript to select the rear / back camera by default and to add some CSS padding-right for the Interpretation row so that instead of it displaying 

01GTIN05000159454100

it displays

01  GTIN  05000159454100

(though not with literal spaces, just CSS padding-right)

I hope this helps.